### PR TITLE
[FE-9812] Restore `TIMESTAMP(3)` type annotation to string literals (take 2)

### DIFF
--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -218,7 +218,7 @@ function formatFilterValue(value, wrapInQuotes, isExact) {
     return wrapInQuotes ? "'" + escapedValue + "'" : escapedValue
   } else if (valueType == "date") {
     return (
-      "'" +
+      "TIMESTAMP(3) '" +
       value
         .toISOString()
         .slice(0, -1)

--- a/src/mapd-crossfilter.js
+++ b/src/mapd-crossfilter.js
@@ -218,7 +218,7 @@ function formatFilterValue(value, wrapInQuotes, isExact) {
     return wrapInQuotes ? "'" + escapedValue + "'" : escapedValue
   } else if (valueType == "date") {
     return (
-      "TIMESTAMP(3) '" +
+      "'" +
       value
         .toISOString()
         .slice(0, -1)

--- a/test/crossfilter.spec.js
+++ b/test/crossfilter.spec.js
@@ -428,7 +428,7 @@ describe("crossfilter", () => {
         dimension = crossfilter.dimension(["age", "sex", "created_at"])
         dimension.filterExact([50, "f", new Date("2016-01-01")])
         expect(dimension.getFilterString()).to.eq(
-          "age = 50 AND sex = 'f' AND created_at = '2016-01-01 00:00:00.000'"
+          "age = 50 AND sex = 'f' AND created_at = TIMESTAMP(3) '2016-01-01 00:00:00.000'"
         )
       })
       it("uses ANY if dim contains array", function() {
@@ -442,7 +442,7 @@ describe("crossfilter", () => {
             dimension = crsfltr.dimension(["age", "sex", "created_at"])
             dimension.filterExact([50, "f", new Date("2016-01-01")])
             expect(dimension.getFilterString()).to.eq(
-              "50 = ANY tableA.age AND tableA.sex = 'f' AND tableA.created_at = '2016-01-01 00:00:00.000'"
+              "50 = ANY tableA.age AND tableA.sex = 'f' AND tableA.created_at = TIMESTAMP(3) '2016-01-01 00:00:00.000'"
             )
           })
       })
@@ -2902,25 +2902,29 @@ describe("Parse parenthesis() for custom expressions", () => {
 describe("replaceRelative", () => {
   it("replaces NOW() with TIMESTAMP", () => {
     expect(replaceRelative("NOW()")).to.match(
-      /^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
+      /^TIMESTAMP\(3\) '[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
     )
   })
 
   it("replaces 'DATE_ADD(days, 1, NOW())' with TIMESTAMP", () => {
     expect(replaceRelative("DATE_ADD(days, 1, NOW())")).to.match(
-      /^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
+      /^TIMESTAMP\(3\) '[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
     )
   })
 
   it("replaces 'DATE_ADD(days, DATEDIFF(days, NOW,  0), NOW())' with TIMESTAMP", () => {
     expect(
       replaceRelative("DATE_ADD(days, DATEDIFF(days, 0, NOW()), NOW())")
-    ).to.match(/^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/)
+    ).to.match(
+      /^TIMESTAMP\(3\) '[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
+    )
   })
 
   it("replaces 'DATE_ADD(days, DATEDIFF(days, NOW,  0)-2, NOW())' with TIMESTAMP", () => {
     expect(
       replaceRelative("DATE_ADD(days, DATEDIFF(days, 0, NOW())-2, NOW())")
-    ).to.match(/^'[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/)
+    ).to.match(
+      /^TIMESTAMP\(3\) '[1-2]\d{3}-[0-1]\d-[0-3]\d [0-2]\d:[0-6]\d:[0-6]\d\.\d{3}'$/
+    )
   })
 })


### PR DESCRIPTION
PR #97 removed all datetime casts/type annotations from generated SQL for performance reasons. However, there was a miscommunication, and we discovered that SQL date/time functions require that their arguments be `CAST`'ed or Calcite throws an error.

This PR restores the cast to all datetime literals. The more sophisticated fix would be to only cast string literal function arguments. However, doing that would require we write a RegEx/parser to identify these arguments, then add a cast to them. This PR's implementation just restores the existing `Date` object formatter's former code (before PR #97) to prepend the cast to Date strings (and, therefore, we already know it works). Note that we retain PR #97's removal of `CAST(... AS TIMESTAMP(3))` in SQL queries, which still gives us **significant** speed improvements over 4.8 (which make the slowdown from this PR insignificant).

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes FE-9812

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.